### PR TITLE
fix: missing ETH literal in spark tokens

### DIFF
--- a/sdk/src/protocols/spark/schema.ts
+++ b/sdk/src/protocols/spark/schema.ts
@@ -1,18 +1,25 @@
 import { z } from "zod"
 import ethTokens from "./_info"
 
-const zToken = z.enum([
+const zTokenDeposit = z.enum([
   ...ethTokens.map((token) => token.symbol),
   "DSR_sDAI",
+  "ETH",
+  ...ethTokens.map((token) => token.token),
+] as [string, string, ...string[]])
+
+const zTokenBorrow = z.enum([
+  ...ethTokens.map((token) => token.symbol),
+  "ETH",
   ...ethTokens.map((token) => token.token),
 ] as [string, string, ...string[]])
 
 export const eth = {
   deposit: z.object({
-    targets: zToken.array(),
+    targets: zTokenDeposit.array(),
   }),
 
   borrow: z.object({
-    targets: zToken.array(),
+    targets: zTokenBorrow.array(),
   }),
 }


### PR DESCRIPTION
fixes https://kit.karpatkey.com/api/v1/permissions/eth/spark/deposit?targets=ETH