### PR TITLE
allow cross-origin API requests

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -16,4 +16,13 @@ export default withNextra({
     })
     return config
   },
+  async headers() {
+    return [
+      {
+        // allow cross-origin requests to the API
+        source: "/api/v1/:path*",
+        headers: [{ key: "Access-Control-Allow-Origin", value: "*" }],
+      },
+    ]
+  },
 })


### PR DESCRIPTION
This is required for integration into portal (or any other client apps for that matter).