### PR TITLE
fix: export to tx-builder helper function

### DIFF
--- a/sdk/src/export.ts
+++ b/sdk/src/export.ts
@@ -2,6 +2,7 @@ import {
   Interface,
   JsonFragment,
   JsonFragmentType,
+  ParamType,
   Result,
   hexlify,
   isBytesLike,
@@ -68,7 +69,8 @@ const decode = (transaction: {
   }
 
   const contractInputsValues = asTxBuilderInputValues(
-    iface.decodeFunctionData(functionFragment, transaction.data)
+    iface.decodeFunctionData(functionFragment, transaction.data),
+    functionFragment.inputs
   )
 
   return {
@@ -94,25 +96,30 @@ const mapInputs = (
   }))
 }
 
-const asTxBuilderInputValues = (result: Result) => {
+const asTxBuilderInputValues = (
+  result: Result,
+  params: readonly ParamType[]
+) => {
   const object: Record<string, string> = {}
-  for (const key of Object.keys(result)) {
-    // skip numeric keys (array indices)
-    if (isNaN(Number(key))) {
-      const value = result[key]
-      let serialized = value
-      if (typeof value === "string") {
-        serialized = value
-      } else if (typeof value === "bigint") {
-        serialized = value.toString()
-      } else if (isBytesLike(value)) {
-        serialized = hexlify(value)
-      } else {
-        serialized = JSON.stringify(value)
-      }
 
-      object[key] = serialized
+  for (const param of params) {
+    const value = result[param.name]
+    let serialized = value
+    if (typeof value === "string") {
+      serialized = value
+    } else if (typeof value === "bigint" || typeof value === "number") {
+      serialized = value.toString()
+    } else if (isBytesLike(value)) {
+      serialized = hexlify(value)
+    } else if (value instanceof Result) {
+      serialized = JSON.stringify(value, (_, v) =>
+        isBytesLike(v) ? hexlify(v) : typeof v === "bigint" ? v.toString() : v
+      )
+    } else {
+      throw new Error(`Unexpected value type: ${typeof value}`)
     }
+
+    object[param.name] = serialized
   }
   return object
 }


### PR DESCRIPTION
contractInputsValues were missing after the upgrade to ethers v6