### PR TITLE
Update wrong/outdated addresses in aave v3 in the 'sdk/eth-sdk/config.ts' file

### DIFF
--- a/sdk/eth-sdk/config.ts
+++ b/sdk/eth-sdk/config.ts
@@ -20,13 +20,12 @@ export const contracts = {
       stkgho: "0x1a88Df1cFe15Af22B3c4c783D4e6F7F9e0C1885d",
     },
     aaveV3: {
-      data_provider: "0x41393e5e337606dc3821075Af65AeE84D7688CBD", //new data provider, based on doc aave v3
+      data_provider: "0x41393e5e337606dc3821075Af65AeE84D7688CBD",
       aaveLendingPoolV3: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
-      wrappedTokenGatewayV3: "0xA434D495249abE33E031Fe71a969B81f3c07950D", //new wrapped token gateway, based on doc aave v3
-      aEthWETH: "0x4d5F47FA6A74757f35C14fD3a6Ef8E3C9BC514E8", // StaticATokenFactory based on doc aave v3
-      //how to get aEthWETH: get protocol data add -> get allreserves -> get aEthWETH -> get aTokenAddress
+      wrappedTokenGatewayV3: "0xA434D495249abE33E031Fe71a969B81f3c07950D",
+      aEthWETH: "0x4d5F47FA6A74757f35C14fD3a6Ef8E3C9BC514E8",
       variableDebtWETH: "0xeA51d7853EEFb32b6ee06b1C12E6dcCA88Be0fFE",
-      stableDebtWETH: "0x0000000000000000000000000000000000000000", //deprecated
+      stableDebtWETH: "0x0000000000000000000000000000000000000000",
     },
     ankr: {
       ETH2_Staking: "0x84db6ee82b7cf3b47e8f19270abde5718b936670",
@@ -149,12 +148,12 @@ export const contracts = {
 export const contractAddressOverrides = {
   gnosis: {
     aaveV3: {
-      data_provider: "0x57038C3e3Fe0a170BB72DE2fD56E98e4d1a69717", //new data provider, based on doc aave v3
+      data_provider: "0x57038C3e3Fe0a170BB72DE2fD56E98e4d1a69717",
       aaveLendingPoolV3: "0xb50201558B00496A145fE76f7424749556E326D8",
-      wrappedTokenGatewayV3: "0x90127A46207e97e4205db5CCC1Ec9D6D43633FD4",//new wrapped token gateway, based on doc aave v3
+      wrappedTokenGatewayV3: "0x90127A46207e97e4205db5CCC1Ec9D6D43633FD4",
       aGnoWXDAI: "0xd0Dd6cEF72143E22cCED4867eb0d5F2328715533",
-      variableDebtWXDAI: "0x281963D7471eCdC3A2Bd4503e24e89691cfe420D", //updated
-      stableDebtWXDAI: "0x0000000000000000000000000000000000000000" //deprecated
+      variableDebtWXDAI: "0x281963D7471eCdC3A2Bd4503e24e89691cfe420D",
+      stableDebtWXDAI: "0x0000000000000000000000000000000000000000"
     },
     aura: {
       booster: "0x98Ef32edd24e2c92525E59afc4475C1242a30184",
@@ -177,12 +176,12 @@ export const contractAddressOverrides = {
   },
   arbitrumOne: {
     aaveV3: {
-      data_provider: "0x7F23D86Ee20D869112572136221e173428DD740B", //new data provider, based on doc aave v3
+      data_provider: "0x7F23D86Ee20D869112572136221e173428DD740B",
       aaveLendingPoolV3: "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
       wrappedTokenGatewayV3: "0x5760E34c4003752329bC77790B1De44C2799F8C3",
       aArbWETH: "0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8",
       variableDebtWETH: "0x0c84331e39d6658Cd6e6b9ba04736cC4c4734351",
-      stableDebtWETH: "0x0000000000000000000000000000000000000000", //deprecated
+      stableDebtWETH: "0x0000000000000000000000000000000000000000",
     },
     balancer: {
       minter: "0xc3ccacE87f6d3A81724075ADcb5ddd85a8A1bB68",

--- a/sdk/eth-sdk/config.ts
+++ b/sdk/eth-sdk/config.ts
@@ -20,12 +20,13 @@ export const contracts = {
       stkgho: "0x1a88Df1cFe15Af22B3c4c783D4e6F7F9e0C1885d",
     },
     aaveV3: {
-      data_provider: "0x7B4EB56E7CD4b454BA8ff71E4518426369a138a3",
-      aaveLendingPoolV3: "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
-      wrappedTokenGatewayV3: "0x893411580e590D62dDBca8a703d61Cc4A8c7b2b9",
-      aEthWETH: "0x4d5F47FA6A74757f35C14fD3a6Ef8E3C9BC514E8",
+      data_provider: "0x41393e5e337606dc3821075Af65AeE84D7688CBD", //new data provider, based on doc aave v3
+      aaveLendingPoolV3: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+      wrappedTokenGatewayV3: "0xA434D495249abE33E031Fe71a969B81f3c07950D", //new wrapped token gateway, based on doc aave v3
+      aEthWETH: "0x4d5F47FA6A74757f35C14fD3a6Ef8E3C9BC514E8", // StaticATokenFactory based on doc aave v3
+      //how to get aEthWETH: get protocol data add -> get allreserves -> get aEthWETH -> get aTokenAddress
       variableDebtWETH: "0xeA51d7853EEFb32b6ee06b1C12E6dcCA88Be0fFE",
-      stableDebtWETH: "0x102633152313C81cD80419b6EcF66d14Ad68949A",
+      stableDebtWETH: "0x0000000000000000000000000000000000000000", //deprecated
     },
     ankr: {
       ETH2_Staking: "0x84db6ee82b7cf3b47e8f19270abde5718b936670",
@@ -148,12 +149,12 @@ export const contracts = {
 export const contractAddressOverrides = {
   gnosis: {
     aaveV3: {
-      data_provider: "0x501B4c19dd9C2e06E94dA7b6D5Ed4ddA013EC741",
+      data_provider: "0x57038C3e3Fe0a170BB72DE2fD56E98e4d1a69717", //new data provider, based on doc aave v3
       aaveLendingPoolV3: "0xb50201558B00496A145fE76f7424749556E326D8",
-      wrappedTokenGatewayV3: "0xfE76366A986B72c3f2923e05E6ba07b7de5401e4",
+      wrappedTokenGatewayV3: "0x90127A46207e97e4205db5CCC1Ec9D6D43633FD4",//new wrapped token gateway, based on doc aave v3
       aGnoWXDAI: "0xd0Dd6cEF72143E22cCED4867eb0d5F2328715533",
-      variableDebtWXDAI: "0xaC8b1cE0548C69318920C3e0b21Db296d5770D57",
-      stableDebtWXDAI: "0x281963D7471eCdC3A2Bd4503e24e89691cfe420D",
+      variableDebtWXDAI: "0x281963D7471eCdC3A2Bd4503e24e89691cfe420D", //updated
+      stableDebtWXDAI: "0x0000000000000000000000000000000000000000" //deprecated
     },
     aura: {
       booster: "0x98Ef32edd24e2c92525E59afc4475C1242a30184",
@@ -176,12 +177,12 @@ export const contractAddressOverrides = {
   },
   arbitrumOne: {
     aaveV3: {
-      data_provider: "0x69FA688f1Dc47d4B5d8029D5a35FB7a548310654",
+      data_provider: "0x7F23D86Ee20D869112572136221e173428DD740B", //new data provider, based on doc aave v3
       aaveLendingPoolV3: "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
-      wrappedTokenGatewayV3: "0xecD4bd3121F9FD604ffaC631bF6d41ec12f1fafb",
+      wrappedTokenGatewayV3: "0x5760E34c4003752329bC77790B1De44C2799F8C3",
       aArbWETH: "0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8",
       variableDebtWETH: "0x0c84331e39d6658Cd6e6b9ba04736cC4c4734351",
-      stableDebtWETH: "0xD8Ad37849950903571df17049516a5CD4cbE55F6",
+      stableDebtWETH: "0x0000000000000000000000000000000000000000", //deprecated
     },
     balancer: {
       minter: "0xc3ccacE87f6d3A81724075ADcb5ddd85a8A1bB68",

--- a/sdk/src/protocols/aave/v3/_arb1Info.ts
+++ b/sdk/src/protocols/aave/v3/_arb1Info.ts
@@ -3,7 +3,7 @@
 export default [
     {
         symbol: "DAI",
-        tokenAddress: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+        token: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -14,7 +14,7 @@ export default [
     },
     {
         symbol: "LINK",
-        tokenAddress: "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4",
+        token: "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -25,7 +25,7 @@ export default [
     },
     {
         symbol: "USDC",
-        tokenAddress: "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+        token: "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -36,7 +36,7 @@ export default [
     },
     {
         symbol: "WBTC",
-        tokenAddress: "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+        token: "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -47,7 +47,7 @@ export default [
     },
     {
         symbol: "WETH",
-        tokenAddress: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+        token: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -58,7 +58,7 @@ export default [
     },
     {
         symbol: "USDT",
-        tokenAddress: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+        token: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -69,7 +69,7 @@ export default [
     },
     {
         symbol: "AAVE",
-        tokenAddress: "0xba5DdD1f9d7F570dc94a51479a000E3BCE967196",
+        token: "0xba5DdD1f9d7F570dc94a51479a000E3BCE967196",
         usageAsCollateralEnabled: true,
         borrowingEnabled: false,
         stableBorrowRateEnabled: false,
@@ -80,7 +80,7 @@ export default [
     },
     {
         symbol: "EURS",
-        tokenAddress: "0xD22a58f79e9481D1a88e00c343885A588b34b68B",
+        token: "0xD22a58f79e9481D1a88e00c343885A588b34b68B",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -91,7 +91,7 @@ export default [
     },
     {
         symbol: "wstETH",
-        tokenAddress: "0x5979D7b546E38E414F7E9822514be443A4800529",
+        token: "0x5979D7b546E38E414F7E9822514be443A4800529",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -102,7 +102,7 @@ export default [
     },
     {
         symbol: "MAI",
-        tokenAddress: "0x3F56e0c36d275367b8C502090EDF38289b3dEa0d",
+        token: "0x3F56e0c36d275367b8C502090EDF38289b3dEa0d",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -113,7 +113,7 @@ export default [
     },
     {
         symbol: "rETH",
-        tokenAddress: "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8",
+        token: "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -124,7 +124,7 @@ export default [
     },
     {
         symbol: "LUSD",
-        tokenAddress: "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
+        token: "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
         usageAsCollateralEnabled: false,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -135,7 +135,7 @@ export default [
     },
     {
         symbol: "USDC",
-        tokenAddress: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+        token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -146,7 +146,7 @@ export default [
     },
     {
         symbol: "FRAX",
-        tokenAddress: "0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F",
+        token: "0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -157,7 +157,7 @@ export default [
     },
     {
         symbol: "ARB",
-        tokenAddress: "0x912CE59144191C1204E64559FE8253a0e49E6548",
+        token: "0x912CE59144191C1204E64559FE8253a0e49E6548",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -168,7 +168,7 @@ export default [
     },
     {
         symbol: "weETH",
-        tokenAddress: "0x35751007a407ca6FEFfE80b3cB397736D2cf4dbe",
+        token: "0x35751007a407ca6FEFfE80b3cB397736D2cf4dbe",
         usageAsCollateralEnabled: true,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,
@@ -179,7 +179,7 @@ export default [
     },
     {
         symbol: "GHO",
-        tokenAddress: "0x7dfF72693f6A4149b17e7C6314655f6A9F7c8B33",
+        token: "0x7dfF72693f6A4149b17e7C6314655f6A9F7c8B33",
         usageAsCollateralEnabled: false,
         borrowingEnabled: true,
         stableBorrowRateEnabled: false,

--- a/sdk/src/protocols/aave/v3/_arb1Info.ts
+++ b/sdk/src/protocols/aave/v3/_arb1Info.ts
@@ -1,0 +1,191 @@
+// This file is auto-generated. Do not edit!
+
+export default [
+    {
+        symbol: "DAI",
+        tokenAddress: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0x82E64f49Ed5EC1bC6e43DAD4FC8Af9bb3A2312EE",
+        variableDebtTokenAddress: "0x8619d80FB0141ba7F184CbF22fd724116D9f7ffC"
+    },
+    {
+        symbol: "LINK",
+        tokenAddress: "0xf97f4df75117a78c1A5a0DBb814Af92458539FB4",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0x191c10Aa4AF7C30e871E70C95dB0E4eb77237530",
+        variableDebtTokenAddress: "0x953A573793604aF8d41F306FEb8274190dB4aE0e"
+    },
+    {
+        symbol: "USDC",
+        tokenAddress: "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0x625E7708f30cA75bfd92586e17077590C60eb4cD",
+        variableDebtTokenAddress: "0xFCCf3cAbbe80101232d343252614b6A3eE81C989"
+    },
+    {
+        symbol: "WBTC",
+        tokenAddress: "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0x078f358208685046a11C85e8ad32895DED33A249",
+        variableDebtTokenAddress: "0x92b42c66840C7AD907b4BF74879FF3eF7c529473"
+    },
+    {
+        symbol: "WETH",
+        tokenAddress: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8",
+        variableDebtTokenAddress: "0x0c84331e39d6658Cd6e6b9ba04736cC4c4734351"
+    },
+    {
+        symbol: "USDT",
+        tokenAddress: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0x6ab707Aca953eDAeFBc4fD23bA73294241490620",
+        variableDebtTokenAddress: "0xfb00AC187a8Eb5AFAE4eACE434F493Eb62672df7"
+    },
+    {
+        symbol: "AAVE",
+        tokenAddress: "0xba5DdD1f9d7F570dc94a51479a000E3BCE967196",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: false,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0xf329e36C7bF6E5E86ce2150875a84Ce77f477375",
+        variableDebtTokenAddress: "0xE80761Ea617F66F96274eA5e8c37f03960ecC679"
+    },
+    {
+        symbol: "EURS",
+        tokenAddress: "0xD22a58f79e9481D1a88e00c343885A588b34b68B",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: true,
+        aTokenAddress: "0x6d80113e533a2C0fe82EaBD35f1875DcEA89Ea97",
+        variableDebtTokenAddress: "0x4a1c3aD6Ed28a636ee1751C69071f6be75DEb8B8"
+    },
+    {
+        symbol: "wstETH",
+        tokenAddress: "0x5979D7b546E38E414F7E9822514be443A4800529",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0x513c7E3a9c69cA3e22550eF58AC1C0088e918FFf",
+        variableDebtTokenAddress: "0x77CA01483f379E58174739308945f044e1a764dc"
+    },
+    {
+        symbol: "MAI",
+        tokenAddress: "0x3F56e0c36d275367b8C502090EDF38289b3dEa0d",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: true,
+        aTokenAddress: "0xc45A479877e1e9Dfe9FcD4056c699575a1045dAA",
+        variableDebtTokenAddress: "0x34e2eD44EF7466D5f9E0b782B5c08b57475e7907"
+    },
+    {
+        symbol: "rETH",
+        tokenAddress: "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0x8Eb270e296023E9D92081fdF967dDd7878724424",
+        variableDebtTokenAddress: "0xCE186F6Cccb0c955445bb9d10C59caE488Fea559"
+    },
+    {
+        symbol: "LUSD",
+        tokenAddress: "0x93b346b6BC2548dA6A1E7d98E9a421B42541425b",
+        usageAsCollateralEnabled: false,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0x8ffDf2DE812095b1D19CB146E4c004587C0A0692",
+        variableDebtTokenAddress: "0xA8669021776Bc142DfcA87c21b4A52595bCbB40a"
+    },
+    {
+        symbol: "USDC",
+        tokenAddress: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0x724dc807b04555b71ed48a6896b6F41593b8C637",
+        variableDebtTokenAddress: "0xf611aEb5013fD2c0511c9CD55c7dc5C1140741A6"
+    },
+    {
+        symbol: "FRAX",
+        tokenAddress: "0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0x38d693cE1dF5AaDF7bC62595A37D667aD57922e5",
+        variableDebtTokenAddress: "0x5D557B07776D12967914379C71a1310e917C7555"
+    },
+    {
+        symbol: "ARB",
+        tokenAddress: "0x912CE59144191C1204E64559FE8253a0e49E6548",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0x6533afac2E7BCCB20dca161449A13A32D391fb00",
+        variableDebtTokenAddress: "0x44705f578135cC5d703b4c9c122528C73Eb87145"
+    },
+    {
+        symbol: "weETH",
+        tokenAddress: "0x35751007a407ca6FEFfE80b3cB397736D2cf4dbe",
+        usageAsCollateralEnabled: true,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0x8437d7C167dFB82ED4Cb79CD44B7a32A1dd95c77",
+        variableDebtTokenAddress: "0x3ca5FA07689F266e907439aFd1fBB59c44fe12f6"
+    },
+    {
+        symbol: "GHO",
+        tokenAddress: "0x7dfF72693f6A4149b17e7C6314655f6A9F7c8B33",
+        usageAsCollateralEnabled: false,
+        borrowingEnabled: true,
+        stableBorrowRateEnabled: false,
+        isActive: true,
+        isFrozen: false,
+        aTokenAddress: "0xeBe517846d0F36eCEd99C735cbF6131e1fEB775D",
+        variableDebtTokenAddress: "0x18248226C16BF76c032817854E7C83a2113B4f06"
+    }
+] as const

--- a/sdk/src/protocols/aave/v3/index.ts
+++ b/sdk/src/protocols/aave/v3/index.ts
@@ -1,7 +1,8 @@
 import { NotFoundError } from "../../../errors"
 import ethTokens from "./_ethInfo"
 import gnoTokens from "./_gnoInfo"
-import { EthToken, GnoToken, Token } from "./types"
+import arb1Tokens from "./_arb1Info"
+import { EthToken, GnoToken, Arb1Token, Token } from "./types"
 import { DelegateToken, StakeToken } from "../v2/types"
 import { findDelegateToken, findStakeToken } from "../v2/index"
 import { depositEther, depositToken, borrowEther, borrowToken } from "./actions"
@@ -92,6 +93,32 @@ export const gno = {
       target === "XDAI"
         ? borrowEther(Chain.gno)
         : borrowToken(Chain.gno, findToken(gnoTokens, target))
+    )
+  },
+}
+
+export const arb1 = {
+  deposit: async ({
+    targets,
+  }: {
+    targets: ("ETH" | Arb1Token["symbol"] | Arb1Token["token"])[]
+  }) => {
+    return targets.flatMap((target) =>
+      target === "ETH"
+        ? depositEther(Chain.arb1)
+        : depositToken(Chain.arb1, findToken(arb1Tokens, target))
+    )
+  },
+
+  borrow: async ({
+    targets,
+  }: {
+    targets: ("ETH" | Arb1Token["symbol"] | Arb1Token["token"])[]
+  }) => {
+    return targets.flatMap((target) =>
+      target === "ETH"
+        ? borrowEther(Chain.arb1)
+        : borrowToken(Chain.arb1, findToken(arb1Tokens, target))
     )
   },
 }

--- a/sdk/src/protocols/aave/v3/schema.ts
+++ b/sdk/src/protocols/aave/v3/schema.ts
@@ -64,3 +64,13 @@ export const gno = {
     targets: zGnoToken.array(),
   }),
 }
+
+export const arb1 = {
+  deposit: z.object({
+    targets: zArb1Token.array(),
+  }),
+
+  borrow: z.object({
+    targets: zArb1Token.array(),
+  }),
+}

--- a/sdk/src/protocols/aave/v3/schema.ts
+++ b/sdk/src/protocols/aave/v3/schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 import ethTokens from "./_ethInfo"
 import gnoTokens from "./_ethInfo"
+import arb1Token from "./_arb1Info"
 import ethStakeTokens from "../v2/stakeTokens"
 import ethDelegateTokens from "../v2/delegateTokens"
 import { zx } from "../../../zx"
@@ -27,6 +28,12 @@ const zGnoToken = z.enum([
   "XDAI",
   ...gnoTokens.map((token) => token.symbol),
   ...gnoTokens.map((token) => token.token),
+] as [string, string, ...string[]])
+
+const zArb1Token = z.enum([
+  "ETH",
+  ...arb1Token.map((token) => token.symbol),
+  ...arb1Token.map((token) => token.token),
 ] as [string, string, ...string[]])
 
 export const eth = {

--- a/sdk/src/protocols/aave/v3/types.ts
+++ b/sdk/src/protocols/aave/v3/types.ts
@@ -1,7 +1,9 @@
 import ethTokens from "./_ethInfo"
 import gnoTokens from "./_gnoInfo"
+import arb1Tokens from "./_arb1Info"
 
 export type EthToken = (typeof ethTokens)[number]
 export type GnoToken = (typeof gnoTokens)[number]
+export type Arb1Token = (typeof arb1Tokens)[number]
 
-export type Token = EthToken | GnoToken
+export type Token = EthToken | GnoToken | Arb1Token


### PR DESCRIPTION
As mentioned in the latest issue, this PR addresses several critical issues related to address configuration for Aave V3 on various networks.
The updates focus on replacing deprecated assets, correcting misassigned addresses, and improving the `_[token]Info.ts` generation process to eliminate private repo dependencies.
These changes ensure better accuracy, alignment with the latest Aave V3 documentation (https://aave.com/docs/resources/addresses), and improved accessibility for users working with Defi-Kit.
