### PR TITLE
chore: fix max call stack size exceeded error by disabling minimization

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -14,6 +14,11 @@ export default withNextra({
       "utf-8-validate": "commonjs utf-8-validate",
       bufferutil: "commonjs bufferutil",
     })
+
+    if (!dev) {
+      config.optimization.minimize = false
+    }
+
     return config
   },
   async headers() {


### PR DESCRIPTION
This seems to be a really strange issue with next.js/webpack minimization, probably in interaction with large eth-sdk config files. 

This change resolves the issue, but it only a hacky quick fix. See: https://nextjs.org/docs/messages/minification-disabled

I'd continue by upgrading next.js and all dependencies to their latests versions. 
