### PR TITLE
chore: update build-actions uses reference for org rename (karpatkey → kpk)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
       
       - name: Build Docker image using composite action
         if: github.event_name != 'release' || github.event.action != 'published'
-        uses: karpatkey/build-actions/build-docker-image@main
+        uses: kpk/build-actions/build-docker-image@main
       
   deploy_prod:                                   # <-- new job just for release deploy
     if: github.event_name == 'release' && github.event.action == 'published'
@@ -50,4 +50,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: deploy prod release
-        uses: karpatkey/build-actions/release-prod@main
+        uses: kpk/build-actions/release-prod@main

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "defi-kit-monorepo",
   "private": true,
-  "repository": "https://github.com/karpatkey/defi-kit.git",
+  "repository": "https://github.com/kpk/defi-kit.git",
   "author": "karpatkey",
   "license": "LGPL-3.0",
   "workspaces": [


### PR DESCRIPTION
## Summary

- Updates `uses: karpatkey/build-actions/...` references to `uses: kpk/build-actions/...` in workflow file(s)

## Context

Part of the org rename from `karpatkey` to `kpk`. GitHub creates redirects so the old references will still work temporarily, but this update ensures correctness once the redirect is eventually removed.

## Test plan
- [ ] Verify CI/CD workflows run successfully after the org rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)